### PR TITLE
changed version md output

### DIFF
--- a/src/main/java/com/skjlls/jenkins/changelog/ChangelogAppenderCallable.java
+++ b/src/main/java/com/skjlls/jenkins/changelog/ChangelogAppenderCallable.java
@@ -39,7 +39,7 @@ public class ChangelogAppenderCallable implements Callable<String, IOException> 
 		StringBuffer sb = new StringBuffer();
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
 		
-		sb.append("== "+version+" "+sdf.format(new Date())+"\n");
+		sb.append("#v"+version+" "+sdf.format(new Date())+"\n");
 		if(changes.size()==0) {
 			sb.append("*no changes*\r\n");
 		}

--- a/src/main/java/com/skjlls/jenkins/changelog/ChangelogAppenderCallable.java
+++ b/src/main/java/com/skjlls/jenkins/changelog/ChangelogAppenderCallable.java
@@ -39,7 +39,7 @@ public class ChangelogAppenderCallable implements Callable<String, IOException> 
 		StringBuffer sb = new StringBuffer();
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
 		
-		sb.append("#v"+version+" "+sdf.format(new Date())+"\n");
+		sb.append("#v"+version+" "+sdf.format(new Date())+"\r\n");
 		if(changes.size()==0) {
 			sb.append("*no changes*\r\n");
 		}


### PR DESCRIPTION
Changed string output to reflect [markdown headlines](https://help.github.com/articles/markdown-basics/#headings).
Now it should create this (example):  
```md
#v1.1.34 2015-09-14 14:23
```